### PR TITLE
StackviewDataController: Rails 5.2+ bug fix

### DIFF
--- a/app/controllers/stackview_data_controller.rb
+++ b/app/controllers/stackview_data_controller.rb
@@ -1,7 +1,7 @@
 class StackviewDataController < ApplicationController
 
-  ApplicationController::ActionController::Parameters.permit_all_parameters = true
-  ApplicationController::ActionController::Parameters.action_on_unpermitted_parameters = :raise
+  ActionController::Parameters.permit_all_parameters = true
+  ActionController::Parameters.action_on_unpermitted_parameters = :raise
 
   # stackview doesn't like it if certain things are blank
   DefaultStackviewDocAttributes = {
@@ -11,7 +11,7 @@ class StackviewDataController < ApplicationController
   }
 
   # config for different call number types; we don't
-  # fully support call number types yet, but are building for it. 
+  # fully support call number types yet, but are building for it.
   # with the exception of the 'test' type
   class_attribute :_config_for_types
   self._config_for_types = {
@@ -30,7 +30,7 @@ class StackviewDataController < ApplicationController
       :fetch_adapter => lambda { RailsStackview::MockFetcher.new }
     },
     'lc' => {
-      # defaults are good. 
+      # defaults are good.
     }
   }
   def self.set_config_for_type(type, attributes)
@@ -65,10 +65,10 @@ class StackviewDataController < ApplicationController
   def fetch
     config = config_for_type( params[:call_number_type] )
 
-    fetch_adapter = config[:fetch_adapter].call    
+    fetch_adapter = config[:fetch_adapter].call
 
     # Make sure defaults are covered
-    docs = fetch_adapter.fetch(params).collect do |d|      
+    docs = fetch_adapter.fetch(params).collect do |d|
       d = d.reverse_merge DefaultStackviewDocAttributes
       # stackview doens't like shelfrank's over 100
       d["shelfrank"] = [d["shelfrank"], 100].min


### PR DESCRIPTION
@acornwe3 // I'm not sure if or how you are cutting releases of this repo for Catalyst, but this trivial change should be applied to a non-master branch (ex. feature/rails-5.2) until our Catalyst upgrade work is ready to deploy into production.

- - - -

Fixes inquisition, traceroute, and rails-erd failures like: "NameError: uninitialized constant ApplicationController::ActionController", example below.

Just trim these config settings to ActionController::Parameters for Rails 5.2.

```bash
beans:jhu-blacklight-rails ewlarson$ bundle exec rake inquisition:traceroute --trace
Logging Deprecations from Blacklight and Deprecation gem...
I, [2020-07-21T14:11:56.917438 #12193]  INFO -- : Celluloid 0.17.4 is running in BACKPORTED mode. [ http://git.io/vJf3J ]
** Invoke inquisition:traceroute (first_time)
** Invoke environment (first_time)
** Execute environment
/Users/ewlarson/Rails/jhu-blacklight-rails/config/initializers/bento_search.rb:104: warning: already initialized constant BentoSearch::EbscoHostEngine::HttpTimeout
/Users/ewlarson/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bento_search-1.7.0/app/search_engines/bento_search/ebsco_host_engine.rb:115: warning: previous definition of HttpTimeout was here
** Execute inquisition:traceroute
rake aborted!
NameError: uninitialized constant ApplicationController::ActionController
/Users/ewlarson/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bundler/gems/rails_stackview-7fc177617970/app/controllers/stackview_data_controller.rb:3:in `<class:StackviewDataController>'
/Users/ewlarson/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bundler/gems/rails_stackview-7fc177617970/app/controllers/stackview_data_controller.rb:1:in `<top (required)>'
```